### PR TITLE
Replacing VM instances automatically when deploying config changes

### DIFF
--- a/production/deploy/gcp/terraform/modules/buyer/service.tf
+++ b/production/deploy/gcp/terraform/modules/buyer/service.tf
@@ -59,6 +59,8 @@ module "autoscaling" {
   cpu_utilization_percent            = var.cpu_utilization_percent
   use_confidential_space_debug_image = var.use_confidential_space_debug_image
   tee_impersonate_service_accounts   = var.tee_impersonate_service_accounts
+
+  runtime_flags                      = var.runtime_flags
 }
 
 module "load_balancing" {

--- a/production/deploy/gcp/terraform/modules/seller/service.tf
+++ b/production/deploy/gcp/terraform/modules/seller/service.tf
@@ -57,6 +57,8 @@ module "autoscaling" {
   vm_startup_delay_seconds           = var.vm_startup_delay_seconds
   use_confidential_space_debug_image = var.use_confidential_space_debug_image
   tee_impersonate_service_accounts   = var.tee_impersonate_service_accounts
+
+  runtime_flags                      = var.runtime_flags
 }
 
 module "load_balancing" {

--- a/production/deploy/gcp/terraform/services/autoscaling/main.tf
+++ b/production/deploy/gcp/terraform/services/autoscaling/main.tf
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+resource "null_resource" "runtime_flags" {
+  triggers = var.runtime_flags
+}
+
 ###############################################################
 #
 #                         FRONTEND
@@ -93,6 +97,7 @@ resource "google_compute_instance_template" "frontends" {
   lifecycle {
     create_before_destroy = true
     ignore_changes = [ name ]
+    replace_triggered_by = [ null_resource.runtime_flags ]
   }
 }
 
@@ -244,6 +249,7 @@ resource "google_compute_instance_template" "backends" {
   lifecycle {
     create_before_destroy = true
     ignore_changes = [ name ]
+    replace_triggered_by = [ null_resource.runtime_flags ]
   }
 }
 

--- a/production/deploy/gcp/terraform/services/autoscaling/main.tf
+++ b/production/deploy/gcp/terraform/services/autoscaling/main.tf
@@ -25,7 +25,7 @@ resource "google_compute_instance_template" "frontends" {
   for_each = var.subnets
 
   region      = each.value.region
-  name        = "${var.operator}-${var.environment}-${var.frontend_service_name}-${each.value.region}-it"
+  name        = "${var.operator}-${var.environment}-${var.frontend_service_name}-${each.value.region}-it-${substr(replace(uuid(), "/-/", ""), 0, 8)}"
   provider    = google-beta
   description = "This template is used to create confidential compute instances, one service per instance."
   tags        = ["allow-hc", "allow-ssh", "allow-all-egress"]
@@ -92,6 +92,7 @@ resource "google_compute_instance_template" "frontends" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ name ]
   }
 }
 
@@ -115,6 +116,18 @@ resource "google_compute_region_instance_group_manager" "frontends" {
   auto_healing_policies {
     health_check      = google_compute_health_check.frontend.id
     initial_delay_sec = var.vm_startup_delay_seconds
+  }
+
+  update_policy {
+    minimal_action = "REPLACE"
+    type = "PROACTIVE"
+  }
+  wait_for_instances_status = "UPDATED"
+  wait_for_instances = true
+  timeouts {
+    create = "1h"
+    delete = "1h"
+    update = "1h"
   }
 }
 
@@ -167,7 +180,7 @@ resource "google_compute_instance_template" "backends" {
   for_each = var.subnets
 
   region      = each.value.region
-  name        = "${var.operator}-${var.environment}-${var.backend_service_name}-${each.value.region}-it"
+  name        = "${var.operator}-${var.environment}-${var.backend_service_name}-${each.value.region}-it-${substr(replace(uuid(), "/-/", ""), 0, 8)}"
   provider    = google-beta
   description = "This template is used to create confidential compute instances, one service per instance."
   tags        = ["allow-hc", "allow-ssh", "allow-backend-ingress", "allow-all-egress"]
@@ -230,6 +243,7 @@ resource "google_compute_instance_template" "backends" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ name ]
   }
 }
 
@@ -253,6 +267,18 @@ resource "google_compute_region_instance_group_manager" "backends" {
   auto_healing_policies {
     health_check      = google_compute_health_check.backend.id
     initial_delay_sec = var.vm_startup_delay_seconds
+  }
+
+  update_policy {
+    minimal_action = "REPLACE"
+    type = "PROACTIVE"
+  }
+  wait_for_instances_status = "UPDATED"
+  wait_for_instances = true
+  timeouts {
+    create = "1h"
+    delete = "1h"
+    update = "1h"
   }
 }
 
@@ -296,7 +322,7 @@ resource "google_compute_instance_template" "collector" {
   for_each = var.subnets
 
   region      = each.value.region
-  name        = "${var.operator}-${var.environment}-${var.collector_service_name}-${each.value.region}-it"
+  name        = "${var.operator}-${var.environment}-${var.collector_service_name}-${each.value.region}-it-${substr(replace(uuid(), "/-/", ""), 0, 8)}"
   provider    = google-beta
   description = "This template is used to create an opentelemetry collector for the region."
   tags        = ["allow-otlp", "allow-hc", "allow-all-egress", ]
@@ -343,6 +369,7 @@ resource "google_compute_instance_template" "collector" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ name ]
   }
 }
 
@@ -366,6 +393,18 @@ resource "google_compute_region_instance_group_manager" "collector" {
   auto_healing_policies {
     health_check      = google_compute_health_check.collector.id
     initial_delay_sec = var.vm_startup_delay_seconds
+  }
+
+  update_policy {
+    minimal_action = "REPLACE"
+    type = "PROACTIVE"
+  }
+  wait_for_instances_status = "UPDATED"
+  wait_for_instances = true
+  timeouts {
+    create = "1h"
+    delete = "1h"
+    update = "1h"
   }
 }
 

--- a/production/deploy/gcp/terraform/services/autoscaling/variables.tf
+++ b/production/deploy/gcp/terraform/services/autoscaling/variables.tf
@@ -145,3 +145,8 @@ variable "collector_machine_type" {
   description = "Machine type for the collector service."
   type        = string
 }
+
+variable "runtime_flags" {
+  description = "List of config variables applied at runtime whose changes still require replacing VM instances"
+  type        = map(string)
+}


### PR DESCRIPTION
This includes "runtime_flags"  which are not applied at runtime yet.

Added random suffix to google_compute_instance_template names as VM templates are immutable