### PR TITLE
Adding explicit dependencies in buyer and seller modules.

### DIFF
--- a/production/deploy/gcp/terraform/modules/buyer/service.tf
+++ b/production/deploy/gcp/terraform/modules/buyer/service.tf
@@ -61,7 +61,7 @@ module "autoscaling" {
   tee_impersonate_service_accounts      = var.tee_impersonate_service_accounts
   runtime_flags                         = var.runtime_flags
   instance_template_waits_for_instances = var.instance_template_waits_for_instances
-  depends_on                            = [ module.security, module.networking, resource.google_secret_manager_secret.runtime_flag_secrets, resource.google_secret_manager_secret_version.runtime_flag_secret_values ]
+  depends_on                            = [module.security, module.networking, resource.google_secret_manager_secret.runtime_flag_secrets, resource.google_secret_manager_secret_version.runtime_flag_secret_values]
 }
 
 module "load_balancing" {

--- a/production/deploy/gcp/terraform/modules/buyer/service.tf
+++ b/production/deploy/gcp/terraform/modules/buyer/service.tf
@@ -61,6 +61,7 @@ module "autoscaling" {
   tee_impersonate_service_accounts      = var.tee_impersonate_service_accounts
   runtime_flags                         = var.runtime_flags
   instance_template_waits_for_instances = var.instance_template_waits_for_instances
+  depends_on                            = [ module.security, module.networking, resource.google_secret_manager_secret.runtime_flag_secrets, resource.google_secret_manager_secret_version.runtime_flag_secret_values ]
 }
 
 module "load_balancing" {

--- a/production/deploy/gcp/terraform/modules/seller/service.tf
+++ b/production/deploy/gcp/terraform/modules/seller/service.tf
@@ -59,6 +59,7 @@ module "autoscaling" {
   tee_impersonate_service_accounts      = var.tee_impersonate_service_accounts
   runtime_flags                         = var.runtime_flags
   instance_template_waits_for_instances = var.instance_template_waits_for_instances
+  depends_on                            = [ module.security, module.networking, resource.google_secret_manager_secret.runtime_flag_secrets, resource.google_secret_manager_secret_version.runtime_flag_secret_values ]
 }
 
 module "load_balancing" {

--- a/production/deploy/gcp/terraform/modules/seller/service.tf
+++ b/production/deploy/gcp/terraform/modules/seller/service.tf
@@ -59,7 +59,7 @@ module "autoscaling" {
   tee_impersonate_service_accounts      = var.tee_impersonate_service_accounts
   runtime_flags                         = var.runtime_flags
   instance_template_waits_for_instances = var.instance_template_waits_for_instances
-  depends_on                            = [ module.security, module.networking, resource.google_secret_manager_secret.runtime_flag_secrets, resource.google_secret_manager_secret_version.runtime_flag_secret_values ]
+  depends_on                            = [module.security, module.networking, resource.google_secret_manager_secret.runtime_flag_secrets, resource.google_secret_manager_secret_version.runtime_flag_secret_values]
 }
 
 module "load_balancing" {


### PR DESCRIPTION
E.g. removing firewall rules early causes healthcheck failures.
For some reason Terraform cannot proceed in destroying MIGs which are in "updating" state.