### PR TITLE
Add support for google providers v5.0.0

### DIFF
--- a/production/deploy/gcp/terraform/environment/demo/buyer/terraform.tf
+++ b/production/deploy/gcp/terraform/environment/demo/buyer/terraform.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "4.64.0"
+      version = "4.84.0"
     }
   }
 }

--- a/production/deploy/gcp/terraform/environment/demo/seller/terraform.tf
+++ b/production/deploy/gcp/terraform/environment/demo/seller/terraform.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "4.64.0"
+      version = "4.84.0"
     }
   }
 }

--- a/production/deploy/gcp/terraform/modules/buyer/service.tf
+++ b/production/deploy/gcp/terraform/modules/buyer/service.tf
@@ -96,7 +96,7 @@ resource "google_secret_manager_secret" "runtime_flag_secrets" {
 
   secret_id = "${var.operator}-${var.environment}-${each.key}"
   replication {
-    automatic = true
+    auto {}
   }
 }
 

--- a/production/deploy/gcp/terraform/modules/seller/service.tf
+++ b/production/deploy/gcp/terraform/modules/seller/service.tf
@@ -94,7 +94,7 @@ resource "google_secret_manager_secret" "runtime_flag_secrets" {
 
   secret_id = "${var.operator}-${var.environment}-${each.key}"
   replication {
-    automatic = true
+    auto {}
   }
 }
 


### PR DESCRIPTION
v4.83.0 introduces new automatic replication syntax for google_secret_manager_secret (`auto {}`). Support for the old syntax (`automatic = true`) was dropped in v5.0.0.

hashicorp/google-beta v5.0.0 is still fresh so this changes version to v4.84.0 (latest without breaking changes) and fixes deprecation warnings.