### PR TITLE
Use empty object as default device signals for Android clients

### DIFF
--- a/services/bidding_service/generate_bids_reactor.cc
+++ b/services/bidding_service/generate_bids_reactor.cc
@@ -115,7 +115,7 @@ constexpr char kJsonStringValueStart[] = R"JSON(":")JSON";
 constexpr char kJsonValueStart[] = R"JSON(":)JSON";
 constexpr char kJsonValueEnd[] = R"JSON(,")JSON";
 constexpr char kJsonEmptyString[] = R"JSON("")JSON";
-constexpr char kEmptyDeviceSignals[] = R"JSON("{}")JSON";
+constexpr char kEmptyDeviceSignals[] = R"JSON({})JSON";
 
 std::string MakeBrowserSignalsForScript(absl::string_view publisher_name,
                                         absl::string_view seller,


### PR DESCRIPTION
[Buyer code wrapper](https://github.com/privacysandbox/bidding-auction-servers/blob/v3.6.0/services/bidding_service/code_wrapper/buyer_code_wrapper.h#L36) adds `wasmHelper` to  `device_signals` `generateBid` parameter but it did not work when it was a string.