### PR TITLE
Allow setting DNS records in seperate GCP project

### DIFF
--- a/production/deploy/gcp/terraform/modules/buyer/service.tf
+++ b/production/deploy/gcp/terraform/modules/buyer/service.tf
@@ -85,6 +85,7 @@ module "load_balancing" {
   collector_service_name            = "collector"
   collector_service_port            = var.collector_service_port
   region_config                     = var.region_config
+  gcp_dns_zones_project_id          = var.gcp_dns_zones_project_id
 }
 
 resource "google_secret_manager_secret" "runtime_flag_secrets" {

--- a/production/deploy/gcp/terraform/modules/buyer/service_vars.tf
+++ b/production/deploy/gcp/terraform/modules/buyer/service_vars.tf
@@ -140,3 +140,9 @@ variable "enable_tee_container_log_redirect" {
   type        = bool
   default     = true
 }
+
+variable "gcp_dns_zones_project_id" {
+  description = "The name of the Google Cloud project where DNS zones are managed."
+  type        = string
+  default     = null
+}

--- a/production/deploy/gcp/terraform/modules/seller/service.tf
+++ b/production/deploy/gcp/terraform/modules/seller/service.tf
@@ -83,6 +83,7 @@ module "load_balancing" {
   collector_service_name            = "collector"
   collector_service_port            = var.collector_service_port
   region_config                     = var.region_config
+  gcp_dns_zones_project_id          = var.gcp_dns_zones_project_id
 }
 
 resource "google_secret_manager_secret" "runtime_flag_secrets" {

--- a/production/deploy/gcp/terraform/modules/seller/service_vars.tf
+++ b/production/deploy/gcp/terraform/modules/seller/service_vars.tf
@@ -145,3 +145,9 @@ variable "enable_tee_container_log_redirect" {
   type        = bool
   default     = true
 }
+
+variable "gcp_dns_zones_project_id" {
+  description = "The name of the Google Cloud project where DNS zones are managed."
+  type        = string
+  default     = null
+}

--- a/production/deploy/gcp/terraform/services/frontend_load_balancing/main.tf
+++ b/production/deploy/gcp/terraform/services/frontend_load_balancing/main.tf
@@ -61,6 +61,7 @@ resource "google_compute_global_forwarding_rule" "xlb_https" {
 resource "google_dns_record_set" "default" {
   name         = "${var.operator}-${var.environment}.${var.frontend_domain_name}."
   managed_zone = var.frontend_dns_zone
+  project      = var.gcp_dns_zones_project_id
   type         = "A"
   ttl          = 10
   rrdatas = [

--- a/production/deploy/gcp/terraform/services/frontend_load_balancing/variables.tf
+++ b/production/deploy/gcp/terraform/services/frontend_load_balancing/variables.tf
@@ -54,7 +54,6 @@ variable "frontend_service_name" {
   type = string
 }
 
-
 variable "google_compute_backend_service_ids" {
   description = "a map with environment as key, the value is google_compute_backend_service_id"
   type        = map(string)
@@ -63,4 +62,10 @@ variable "google_compute_backend_service_ids" {
 variable "traffic_weights" {
   description = "a map with environment as key, the value is traffic_weight between 0~1000"
   type        = map(number)
+}
+
+variable "gcp_dns_zones_project_id" {
+  description = "The name of the Google Cloud project where DNS zones are managed."
+  type        = string
+  default     = null
 }

--- a/production/deploy/gcp/terraform/services/load_balancing/main.tf
+++ b/production/deploy/gcp/terraform/services/load_balancing/main.tf
@@ -129,6 +129,7 @@ resource "google_compute_global_forwarding_rule" "collectors" {
 resource "google_dns_record_set" "collector" {
   name         = "${var.collector_service_name}-${var.operator}-${var.environment}.${var.frontend_domain_name}."
   managed_zone = var.frontend_dns_zone
+  project      = var.gcp_dns_zones_project_id
   type         = "A"
   ttl          = 10
   routing_policy {

--- a/production/deploy/gcp/terraform/services/load_balancing/variables.tf
+++ b/production/deploy/gcp/terraform/services/load_balancing/variables.tf
@@ -39,6 +39,12 @@ variable "gcp_project_id" {
   type        = string
 }
 
+variable "gcp_dns_zones_project_id" {
+  description = "The name of the Google Cloud project where DNS zones are managed."
+  type        = string
+  default     = null
+}
+
 variable "frontend_domain_name" {
   description = "Domain name for global external LB"
   type        = string
@@ -90,8 +96,6 @@ variable "collector_instance_group_managers" {
 variable "collector_service_name" {
   type = string
 }
-
-
 
 variable "collector_service_port" {
   description = "The grpc port that receives traffic destined for the OpenTelemetry collector."


### PR DESCRIPTION
Add `gcp_dns_zones_project_id` to service level for seller and buyer modules to configure the resource `"google_dns_record_set" "collector"` 

The existing setup assumes that the GCP project used for B&A is also responsible managing DNS and domains, which isn't always the case.