### PR TITLE
Support custom gcp ssl policies in frontend load balancer

### DIFF
--- a/production/deploy/gcp/terraform/environment/demo/buyer/buyer.tf
+++ b/production/deploy/gcp/terraform/environment/demo/buyer/buyer.tf
@@ -49,6 +49,7 @@ locals {
   # If you specify a certificate_map_id, you do not need to specify an ssl_certificate_id.
   frontend_domain_ssl_certificate_id = "" # Example: "projects/${local.gcp_project_id}/global/sslCertificates/bfe-${local.environment}"
   frontend_certificate_map_id        = "" # Example: "//certificatemanager.googleapis.com/projects/test/locations/global/certificateMaps/wildcard-cert-map"
+  frontend_ssl_policy_id             = "" # Example: "projects/${local.gcp_project_id}/global/sslPolicies/bfe-ssl-policy
   buyer_domain_name                  = "" # Example: bfe-gcp.com
   frontend_dns_zone                  = "" # Example: "bfe-gcp-com"
 
@@ -246,6 +247,7 @@ module "buyer_frontend_load_balancing" {
 
   frontend_domain_ssl_certificate_id = local.frontend_domain_ssl_certificate_id
   frontend_certificate_map_id        = local.frontend_certificate_map_id
+  frontend_ssl_policy_id             = local.frontend_ssl_policy_id
   frontend_service_name              = "bfe"
   google_compute_backend_service_ids = {
     for buyer_key, buyer in module.buyer :

--- a/production/deploy/gcp/terraform/environment/demo/seller/seller.tf
+++ b/production/deploy/gcp/terraform/environment/demo/seller/seller.tf
@@ -49,6 +49,7 @@ locals {
   # If you specify a certificate_map_id, you do not need to specify an ssl_certificate_id.
   frontend_domain_ssl_certificate_id = "" # Example: "projects/${local.gcp_project_id}/global/sslCertificates/sfe-${local.environment}"
   frontend_certificate_map_id        = "" # Example: "//certificatemanager.googleapis.com/projects/test/locations/global/certificateMaps/wildcard-cert-map"
+  frontend_ssl_policy_id             = "" # Example: "projects/${local.gcp_project_id}/global/sslPolicies/sfe-ssl-policy
   seller_domain_name                 = "" # Example: sfe-gcp.com
   frontend_dns_zone                  = "" # Example: "sfe-gcp-com"
 
@@ -224,6 +225,7 @@ module "seller_frontend_load_balancing" {
 
   frontend_domain_ssl_certificate_id = local.frontend_domain_ssl_certificate_id
   frontend_certificate_map_id        = local.frontend_certificate_map_id
+  frontend_ssl_policy_id             = local.frontend_ssl_policy_id
   frontend_service_name              = "sfe"
   google_compute_backend_service_ids = {
     for seller_key, seller in module.seller :

--- a/production/deploy/gcp/terraform/services/frontend_load_balancing/main.tf
+++ b/production/deploy/gcp/terraform/services/frontend_load_balancing/main.tf
@@ -38,6 +38,7 @@ resource "google_compute_target_https_proxy" "default" {
   name             = "${var.operator}-${var.environment}-https-lb-proxy"
   url_map          = google_compute_url_map.default.id
   ssl_certificates = var.frontend_certificate_map_id == "" ? [var.frontend_domain_ssl_certificate_id] : null
+  ssl_policy       = var.frontend_ssl_policy_id == "" ? null : var.frontend_ssl_policy_id
   certificate_map  = var.frontend_certificate_map_id == "" ? null : var.frontend_certificate_map_id
 }
 

--- a/production/deploy/gcp/terraform/services/frontend_load_balancing/variables.tf
+++ b/production/deploy/gcp/terraform/services/frontend_load_balancing/variables.tf
@@ -50,6 +50,12 @@ variable "frontend_certificate_map_id" {
   default     = ""
 }
 
+variable "frontend_ssl_policy_id" {
+  description = "A GCP ssl policy id. Example: projects/test-projects/global/sslPolicies/test-ssl-policy."
+  type        = string
+  default     = ""
+}
+
 variable "frontend_service_name" {
   type = string
 }


### PR DESCRIPTION
Our organization policy requires a secure SSL policy attached to each frontend load balancer in GCP.

This PR adds support for setting custom ones for seller and buyer. 
The default policy used if none was provided.

Perhaps these scripts should default to some `MODERN/TLS 1.2` profile instead of `COMPATIBLE`?
I wouldn't expect any legacy clients to SFE or BFE.