### PR TITLE
GCP Cloud build and startup scripts for local testing images

### DIFF
--- a/production/packaging/gcp/cloud_build/README.md
+++ b/production/packaging/gcp/cloud_build/README.md
@@ -40,8 +40,12 @@ a parent connection and your github repo.
 
 ### Terraform
 
-Fill out the `backend` block in [terraform.tf](./terraform.tf) and all fields in
-[cloud_build.auto.tfvars.json](./cloud_build.auto.tfvars.json).
+1. In [terraform.tf](./terraform.tf) fill out the `backend` block with the Cloud Storage
+bucket name to store terraform state files (you need to create this bucket manually beforehand).
+2. In [cloud_build.auto.tfvars](./cloud_build.auto.tfvars) fill out all the fields.
+
+Note: You can choose to have terraform create a new Cloud Build service account for you,
+or reuse existing Service Account. Uncomment either of the option.
 
 Then, in the same directory as this README, run:
 
@@ -50,7 +54,7 @@ terraform init
 terraform apply # You will have to type 'yes' if you approve of the plan.
 ```
 
-This will create triggers that automatically build `prod` and `non_prod` images of the Bidding and
-Auction Services every time a new release (tag) is pushed to the
+This will create triggers that automatically build `prod`, `non_prod`, and `non_prod_local_testing`
+images of the Bidding and Auction Services every time a new release (tag) is pushed to the
 [connected repo](#connecting-to-github). The images will be pushed to an Artifact Registry of your
-choice, using the default compute service account.
+choice.

--- a/production/packaging/gcp/cloud_build/cloud_build.auto.tfvars
+++ b/production/packaging/gcp/cloud_build/cloud_build.auto.tfvars
@@ -1,0 +1,26 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http: //www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = "gtech-privacy-baservices-dev"
+artifact_registry_repo_name = "bidding-auction-servers-image-repo"
+artifact_registry_repo_location = "us-central1"
+cloud_build_linked_repository = "projects/gtech-privacy-baservices-dev/locations/us-central1/connections/github-seburan/repositories/Seburan-bidding-auction-servers"
+
+# [1] Uncomment below lines if you like Terraform grant needed permissions to
+# pre-existing service accounts
+# cloud_build_service_account_email = "build-sa@<project>.iam.gserviceaccount.com"
+
+# [2] Uncomment below lines if you like Terraform to create service accounts
+# and needed permissions granted e.g "build-sa" or "worker-sa"
+# cloud_build_service_account_name = "build-sa"

--- a/production/packaging/gcp/cloud_build/cloud_build.auto.tfvars
+++ b/production/packaging/gcp/cloud_build/cloud_build.auto.tfvars
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project_id = "gtech-privacy-baservices-dev"
-artifact_registry_repo_name = "bidding-auction-servers-image-repo"
+project_id = "my-gcp-project"
+artifact_registry_repo_name = "my-image-repo"
 artifact_registry_repo_location = "us-central1"
-cloud_build_linked_repository = "projects/gtech-privacy-baservices-dev/locations/us-central1/connections/github-seburan/repositories/Seburan-bidding-auction-servers"
+cloud_build_linked_repository = "projects/my-gcp-project/locations/my-location/connections/my-parent-connection/repositories/my-mirrored-github-repo"
 
 # [1] Uncomment below lines if you like Terraform grant needed permissions to
 # pre-existing service accounts
@@ -23,4 +23,4 @@ cloud_build_linked_repository = "projects/gtech-privacy-baservices-dev/locations
 
 # [2] Uncomment below lines if you like Terraform to create service accounts
 # and needed permissions granted e.g "build-sa" or "worker-sa"
-# cloud_build_service_account_name = "build-sa"
+cloud_build_service_account_name = "build-sa"

--- a/production/packaging/gcp/cloud_build/cloud_build.auto.tfvars.json
+++ b/production/packaging/gcp/cloud_build/cloud_build.auto.tfvars.json
@@ -1,6 +1,0 @@
-{
-    "project_id": "my-gcp-project",
-    "artifact_registry_repo_name": "my-image-repo",
-    "artifact_registry_repo_location": "us-central1",
-    "cloud_build_linked_repository": "projects/my-gcp-project/locations/my-location/connections/my-parent-connection/repositories/my-mirrored-github-repo"
-}

--- a/production/packaging/gcp/cloud_build/cloudbuild.yaml
+++ b/production/packaging/gcp/cloud_build/cloudbuild.yaml
@@ -31,7 +31,8 @@ steps:
       --service-path bidding_service \
       --service-path seller_frontend_service \
       --service-path auction_service \
-      --instance gcp --platform gcp \
+      --instance ${_INSTANCE} \
+      --platform gcp \
       --build-flavor ${_BUILD_FLAVOR} \
       --gcp-image-tag ${TAG_NAME} \
       --gcp-image-repo ${_GCP_IMAGE_REPO} \
@@ -41,6 +42,7 @@ substitutions:
     # CloudBuild Trigger GUI.
     # See https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
     # for more information.
+    _INSTANCE: gcp # Default. Use local for building image for local testing
     _BUILD_FLAVOR: prod # Default. Use non_prod for enhanced logging output.
     _GCP_IMAGE_REPO: us-docker.pkg.dev/${PROJECT_ID}/services # Default. Artifact Registry repo to house images for each service.
 timeout: 10800s

--- a/production/packaging/gcp/lib_gcp_artifacts.sh
+++ b/production/packaging/gcp/lib_gcp_artifacts.sh
@@ -59,7 +59,7 @@ function upload_image_to_repo() {
   # authenticated to the repo.
   docker load -i "${WORKSPACE}/${server_image}"
 
-  local -a image_tags=("${env_tag}" "${git_tag}")
+  local -a image_tags=("${env_tag}" "${git_tag}" "latest")
   if [[ "${KOKORO_ENV_NAME}" == "staging" ]] && [[ "${KOKORO_ENV_JOB_TYPE}" == "continuous" ]]; then
     local -r version="$(cat "${WORKSPACE}/version.txt")"
     local -r release_tag="${repo_image_uri}:staging-release-${build_flavor}-${version}"

--- a/tools/debug/start_auction
+++ b/tools/debug/start_auction
@@ -13,7 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+print_usage() {
+    cat << USAGE
+Usage:
+  <options>
+  --build_image_uri <uri>                If you build on a different machine and store your local testing images in a private registry, specify the uri of the image
+  -h, --help                             Print usage information
+USAGE
+    exit 0
+}
+
 source $(dirname "$0")/common
+
+declare BUILD_IMAGE_URI=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build_image_uri)
+      BUILD_IMAGE_URI="$2"
+      shift 2
+      ;;
+    -h | --help) print_usage ;;
+    *) print_usage ;;
+  esac
+done
 
 SERVER_START_CMD=$(cat << END
 /server/bin/server \
@@ -50,6 +73,10 @@ if [[ $1 == "--gdb" ]]; then
   --docker-network host --image build-debian \
   --cmd "apt-get update && apt-get -y install gdb && gdb -ex=r --args ${SERVER_START_CMD}"
 else
-  docker_image_uri="$(docker load -i dist/debian/auction_service_image.tar | sed -nr "s/^Loaded image: (.*)$/\1/p")"
+  if [[ -n "${BUILD_IMAGE_URI}" ]]; then
+    docker_image_uri="${BUILD_IMAGE_URI}"
+  else
+    docker_image_uri="$(docker load -i dist/debian/auction_service_image.tar | sed -nr "s/^Loaded image: (.*)$/\1/p")"
+  fi
   docker run -it "${DOCKER_RUN_ARGS[@]}" "${docker_image_uri}" -c "${SERVER_START_CMD}"
 fi

--- a/tools/debug/start_bfe
+++ b/tools/debug/start_bfe
@@ -13,7 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+print_usage() {
+    cat << USAGE
+Usage:
+  <options>
+  --build_image_uri <uri>                If you build on a different machine and store your local testing images in a private registry, specify the uri of the image
+  -h, --help                             Print usage information
+USAGE
+    exit 0
+}
+
 source $(dirname "$0")/common
+
+declare BUILD_IMAGE_URI=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build_image_uri)
+      BUILD_IMAGE_URI="$2"
+      shift 2
+      ;;
+    -h | --help) print_usage ;;
+    *) print_usage ;;
+  esac
+done
 
 BUYER_KV_SERVER_ADDR="${BUYER_KV_SERVER_ADDR:-}"
 BUYER_TKV_V2_SERVER_ADDR="${BUYER_TKV_V2_SERVER_ADDR:-}"
@@ -59,6 +82,10 @@ if [[ $1 == "--gdb" ]]; then
   --docker-network host --image build-debian \
   --cmd "apt-get update && apt-get -y install gdb && gdb -ex=r --args ${SERVER_START_CMD}"
 else
-  docker_image_uri="$(docker load -i dist/debian/buyer_frontend_service_image.tar | sed -nr "s/^Loaded image: (.*)$/\1/p")"
+  if [[ -n "${BUILD_IMAGE_URI}" ]]; then
+    docker_image_uri="${BUILD_IMAGE_URI}"
+  else
+    docker_image_uri="$(docker load -i dist/debian/buyer_frontend_service_image.tar | sed -nr "s/^Loaded image: (.*)$/\1/p")"
+  fi
   docker run -it "${DOCKER_RUN_ARGS[@]}" "${docker_image_uri}" -c "${SERVER_START_CMD}"
 fi

--- a/tools/debug/start_bidding
+++ b/tools/debug/start_bidding
@@ -22,6 +22,7 @@ Usage:
   --use-with-generateBid-file <path>     Use the provided generateBid file for bidding. Path MUST be relative to project root.
   --inference_sidecar_binary_path <path> Path to the inference sidecar binary (default: "/server/bin/inference_sidecar_pytorch_v2_1_1")
   --generate_bid_model_path <path>       Use the provided model for inference. Path MUST be relative to project root (default: "services/inference_sidecar/common/testdata/models/pytorch_generate_bid_model.pt")
+  --build_image_uri <uri>                If you build on a different machine and store your local testing images in a private registry, specify the uri of the image
   -h, --help                             Print usage information
 USAGE
     exit 0
@@ -39,6 +40,7 @@ declare -i ENABLE_INFERENCE=0
 declare -i USE_GDB=0
 declare GENERATE_BID_FILEPATH=""
 declare -i FETCH_MODE=0
+declare BUILD_IMAGE_URI=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -61,6 +63,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --generate_bid_model_path)
       GENERATE_BID_MODEL_PATH="$2"
+      shift 2
+      ;;
+    --build_image_uri)
+      BUILD_IMAGE_URI="$2"
       shift 2
       ;;
     -h | --help) print_usage ;;
@@ -193,7 +199,11 @@ if [[ ${USE_GDB} -eq 1 ]]; then
   --docker-network host --image build-debian \
   --cmd "apt-get update && apt-get -y install gdb && gdb -ex=r --args ${SERVER_START_CMD}"
 else
-  docker_image_uri="$(docker load -i dist/debian/bidding_service_image.tar | sed -nr "s/^Loaded image: (.*)$/\1/p")"
+  if [[ -n "${BUILD_IMAGE_URI}" ]]; then
+    docker_image_uri="${BUILD_IMAGE_URI}"
+  else
+    docker_image_uri="$(docker load -i dist/debian/bidding_service_image.tar | sed -nr "s/^Loaded image: (.*)$/\1/p")"
+  fi
   if [[ -n "${GENERATE_BID_FILEPATH}" ]]; then
     DOCKER_RUN_ARGS+=(
       "--volume=${PROJECT_ROOT}/${GENERATE_BID_FILEPATH}:/generateBid.js"

--- a/tools/debug/start_sfe
+++ b/tools/debug/start_sfe
@@ -13,7 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+print_usage() {
+    cat << USAGE
+Usage:
+  <options>
+  --build_image_uri <uri>                If you build on a different machine and store your local testing images in a private registry, specify the uri of the image
+  -h, --help                             Print usage information
+USAGE
+    exit 0
+}
+
 source $(dirname "$0")/common
+
+declare BUILD_IMAGE_URI=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build_image_uri)
+      BUILD_IMAGE_URI="$2"
+      shift 2
+      ;;
+    -h | --help) print_usage ;;
+    *) print_usage ;;
+  esac
+done
 
 AUCTION_SERVER_ADDR="${AUCTION_SERVER_ADDR:-127.0.0.1:${AUCTION_PORT}}"
 KEY_VALUE_SIGNALS_ADDR="${KEY_VALUE_SIGNALS_ADDR:-}"
@@ -73,6 +96,10 @@ if [[ $1 == "--gdb" ]]; then
   --docker-network host --image build-debian \
   --cmd "apt-get update && apt-get -y install gdb && gdb -ex=r --args ${SERVER_START_CMD}"
 else
-  docker_image_uri="$(docker load -i dist/debian/seller_frontend_service_image.tar | sed -nr "s/^Loaded image: (.*)$/\1/p")"
+  if [[ -n "${BUILD_IMAGE_URI}" ]]; then
+    docker_image_uri="${BUILD_IMAGE_URI}"
+  else
+    docker_image_uri="$(docker load -i dist/debian/seller_frontend_service_image.tar | sed -nr "s/^Loaded image: (.*)$/\1/p")"
+  fi
   docker run -it "${DOCKER_RUN_ARGS[@]}" "${docker_image_uri}" -c "${SERVER_START_CMD}"
 fi


### PR DESCRIPTION
This pull request proposes the following changes : 
1. update the GCP Cloud Build terraform script to add an additional trigger to build images for local testing
1.1. add support for a Cloud Build service account
1.2 add a new trigger
2. add the "latest" tag to the pushed image for convenience when pulling the "latest" image for local testing
3. update the tools/debug script to use a pre-build image from private registry