### PR TITLE
Add terraform variables to force AWS availability zones

### DIFF
--- a/production/deploy/aws/terraform/modules/buyer/service.tf
+++ b/production/deploy/aws/terraform/modules/buyer/service.tf
@@ -36,6 +36,7 @@ module "networking" {
   operator       = var.operator
   environment    = var.environment
   vpc_cidr_block = var.vpc_cidr_block
+  forced_availability_zones = var.forced_availability_zones
 }
 
 module "security_groups" {
@@ -189,7 +190,7 @@ module "autoscaling_bidding" {
   operator                        = var.operator
   enclave_debug_mode              = var.enclave_debug_mode
   service                         = "bidding"
-  autoscaling_subnet_ids          = module.networking.private_subnet_ids
+  autoscaling_subnet_ids          = var.auto_scaling_use_first_zone ? [module.networking.private_subnet_ids[0]] : module.networking.private_subnet_ids
   instance_ami_id                 = coalesce(var.bidding_instance_ami_id, data.aws_ami_ids.bidding_amis.ids...)
   instance_security_group_id      = module.security_groups.instance_security_group_id
   instance_type                   = var.bidding_instance_type
@@ -280,7 +281,7 @@ module "autoscaling_bfe" {
   operator                        = var.operator
   enclave_debug_mode              = var.enclave_debug_mode
   service                         = "bfe"
-  autoscaling_subnet_ids          = module.networking.private_subnet_ids
+  autoscaling_subnet_ids          = var.auto_scaling_use_first_zone ? [module.networking.private_subnet_ids[0]] : module.networking.private_subnet_ids
   instance_ami_id                 = coalesce(var.bfe_instance_ami_id, data.aws_ami_ids.buyer_frontend_amis.ids...)
   instance_security_group_id      = module.security_groups.instance_security_group_id
   instance_type                   = var.bfe_instance_type

--- a/production/deploy/aws/terraform/modules/buyer/service_vars.tf
+++ b/production/deploy/aws/terraform/modules/buyer/service_vars.tf
@@ -241,3 +241,15 @@ variable "coordinator_role_arns" {
   description = "ARNs for coordinator roles."
   type        = list(string)
 }
+
+variable "forced_availability_zones" {
+  description = "Only use those forced availability zones. Not all instances types are available in all zones"
+  type        = set(string)
+  default     = []
+}
+
+variable "auto_scaling_use_first_zone" {
+  description = "Only use first zone for autoscaling"
+  type        = bool
+  default     = false
+}

--- a/production/deploy/aws/terraform/services/networking/main.tf
+++ b/production/deploy/aws/terraform/services/networking/main.tf
@@ -36,6 +36,14 @@ resource "aws_vpc" "vpc" {
 # Get information about available AZs.
 data "aws_availability_zones" "azs" {
   state = "available"
+  dynamic "filter" {
+  for_each = length(var.forced_availability_zones) > 0 ? [1] : []
+
+    content {
+      name   = "zone-name"
+      values = var.forced_availability_zones
+    }
+  }
 }
 
 # Create public subnets used to connect to instances in private subnets.

--- a/production/deploy/aws/terraform/services/networking/variables.tf
+++ b/production/deploy/aws/terraform/services/networking/variables.tf
@@ -28,3 +28,9 @@ variable "vpc_cidr_block" {
   description = "CIDR range for the VPC where KV server will be deployed."
   type        = string
 }
+
+variable "forced_availability_zones" {
+  description = "Only use those forced availability zones."
+  type = set(string)
+  default     = []
+}


### PR DESCRIPTION
- `forced_availability_zones`, by default all zones are selected, not all instances types are available on all zones which may produce errors, setting allows to select a subset of zones
- `auto_scaling_use_first_zone`, reduce VPC charges across all zones for small POC deployments that only need 1 single zone and instance